### PR TITLE
Fix typo in 13.3.3.4 Exercise 4

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -384,7 +384,7 @@ But, there are a few heuristics to consider that would account for some common c
 - ends in `ise` instead of `ize`
 - ends in `yse`
 
-The regex `ou|ise^|ae|oe|yse^` would match these.
+The regex `ou|ise$|ae|oe|yse$` would match these.
 
 There are other [spelling differences between American and British English] (https://en.wikipedia.org/wiki/American_and_British_English_spelling_differences) but they are not patterns amenable to regular expressions.
 It would require a dictionary with differences in spellings for different words.


### PR DESCRIPTION
End-of-string matcher was incorrectly specified as "^" instead of "$"