### PR TITLE
Updates answer for 13.3.4.1 Exercise 1

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -436,16 +436,10 @@ Describe the equivalents of `?`, `+`, `*` in `{m,n}` form.
 `r BeginAnswer()`
 
 ----- ---------  ----------------------------------
-`-`   `{,1}`     Match at most 1
+`?`   `{0,1}`    Match at most 1
 `+`   `{1,}`     Match one or more
-`*`   None       No equivalent
+`*`   `{0,}`     0 or more
 ----- ---------  ----------------------------------
-
-The `*` pattern has no `{m,n}` equivalent since there is no upper bound on the number of matches. The expected pattern `{,}` is not valid.
-```{r error=TRUE,eval=is_html}
-str_view("abcd", ".{,}")
-```
-
 
 `r EndAnswer()`
 

--- a/strings.Rmd
+++ b/strings.Rmd
@@ -437,8 +437,8 @@ Describe the equivalents of `?`, `+`, `*` in `{m,n}` form.
 
 ----- ---------  ----------------------------------
 `?`   `{0,1}`    Match at most 1
-`+`   `{1,}`     Match one or more
-`*`   `{0,}`     0 or more
+`+`   `{1,}`     Match 1 or more
+`*`   `{0,}`     Match 0 or more
 ----- ---------  ----------------------------------
 
 `r EndAnswer()`


### PR DESCRIPTION
The table incorrectly specified "-" as matcher instead of "?"
The answers to the equivalent {m,n} patterns for "?" and "*" were incorrect: for "?" the given pattern would have thrown an error for not including an explicit lower bound on the range (0), and similarly, there is a correct pattern for "*" where you would just specify the lower bound as "0" with no upper bound