### PR TITLE
Corrected solution for 3.6.6 plot 6

### DIFF
--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -514,8 +514,9 @@ ggplot(mpg, aes(x = displ, y = hwy)) +
 ```
 
 ```{r}
-ggplot(mpg, aes(x = displ, y = hwy, fill = drv)) +
-  geom_point(colour = "white", shape = 21)
+ggplot(mpg, aes(x = displ, y = hwy)) + 
+   geom_point(size=10, color="white")+ 
+   geom_point(aes(size=1,color=drv))
 ```
 
 `r EndAnswer()`


### PR DESCRIPTION
Thanks for the solutions.  I can across your site when trying to figure out a correct way to code this exercise.  Your solution, like my original solution, was very close to what was shown, however, if you enlarge the points you'll notice that the white boarder of the shape overlaps across the neighboring points instead of having the white create a halo effect around the points as shown in the book's exercise. To get that halo look, it seems like one needs to layer a set of colored points on top of a larger set of white points.  There may be a more elegant solution than this one but it is closer to the book than the one you currently have published.  One thing I don't like about my solution is why the size aesthetic doesn't seem to be relative between the two `geom_points`. 

Compare: 
# original solution (with larger size to show the overlap) 
ggplot(mpg, aes(x = displ, y = hwy, fill = drv)) +
  geom_point(colour = "white", shape = 21, size=4)

# solution that matches the book with the "halo" look
ggplot(data = mpg, mapping = aes(x = displ, y = hwy)) + 
   geom_point(size=10, color="white")+ 
   geom_point(aes(size=1,color=drv))