### PR TITLE
separate question and answer list

### DIFF
--- a/transform.Rmd
+++ b/transform.Rmd
@@ -29,6 +29,8 @@ Find all flights that
 
 `r EndQuestion()`
 
+<!-- end of the question list -->
+
 `r BeginAnswer()`
 
 1.  Since delay is in minutes, find


### PR DESCRIPTION
In html output, answer is numbered 8-14, which is quite confusing.

My solution may not be portable (especially for PDF), you might insert some non-indented content like 'Here is the answer' or 'Let us deal with them one by one'. Please refer to https://localhost:1035/MANUAL.html#ending-a-list.