### PR TITLE
Use [ instead of [[ for question 20.4.6

### DIFF
--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -419,12 +419,12 @@ When you subset with positive integers that are larger than the length of the ve
 #> [1] NA NA
 ```
 
-When a vector is subset with a name that doesn't exist, an error is generated.
-
+Similarly, when a vector is subset with a name that doesn't exist, `NA` values are returned for those names that don't exist and the names themselves.
 
 ```r
-c(a = 1, 2)[["b"]]
-#> Error in c(a = 1, 2)[["b"]]: subscript out of bounds
+c(a = 1, 2)["b"]
+#> <NA> 
+  NA
 ```
 
 </div>


### PR DESCRIPTION
At the end of section 20.4, Hadley writes

> There is an important variation of [ called [[. [[ only ever extracts a single element, and always drops names. It’s a good idea to use it whenever you want to make it clear that you’re extracting a single item, as in a for loop. The distinction between [ and [[ is most important for lists, as we’ll see shortly.

I think `[` should be used here.