### PR TITLE
preserve the order in the original R code for Exercise 20.5.1

### DIFF
--- a/diagrams/nested_set_1.dot
+++ b/diagrams/nested_set_1.dot
@@ -2,21 +2,21 @@ digraph nested_set_1 {
   node[shape=box]
   graph[style=rounded]
   # subgraph for R information
-  subgraph cluster0 {
+  subgraph cluster_abcdef {
     node[style=filled,fillcolor=gray90]
-    "a"
     "b"
-    subgraph cluster1 {
+    "a"
+    subgraph cluster_ef {
       graph[fillcolor=gray90,style="rounded,filled"]
       node[fillcolor=gray80]
-      "c"
-      "d"
-    }
-    subgraph cluster2 {
-      graph[fillcolor=gray90,style="rounded,filled"]
-      node[fillcolor=gray80]
-      "e"
       "f"
+      "e"
+    }
+    subgraph cluster_cd {
+      graph[fillcolor=gray90,style="rounded,filled"]
+      node[fillcolor=gray80]
+      "d"
+      "c"
     }
   }
 }


### PR DESCRIPTION
Although _r4ds_ says "The orientation of the children (i.e. rows or columns) isn’t important", I still argue that 

![image](https://user-images.githubusercontent.com/15871952/43671754-6d72ee8c-97d2-11e8-8d24-f7a4e653b35b.png)

looks much more intuitive than

![image](https://user-images.githubusercontent.com/15871952/43671757-7e9df972-97d2-11e8-82a8-92f7e37e6797.png)

for `list(a, b, list(c, d), list(e, f))`