### PR TITLE
warp lines at 80 width in `caching.Rmd` Exercise 27.3.4

### DIFF
--- a/rmarkdown/caching.Rmd
+++ b/rmarkdown/caching.Rmd
@@ -33,5 +33,6 @@ print(lubridate::now())
 w <- y + z
 ```
 
-If this document is knit repeatedly, the value  printed by `lubridate::now()` will be the same for all chunks,
-and the same as the first time the document was run with caching.
+If this document is knit repeatedly, the value  printed by `lubridate::now()` 
+will be the same for all chunks, and the same as the first time the document was
+run with caching.


### PR DESCRIPTION
So we won't see a horizontal scrolling bar at the end of https://jrnold.github.io/r4ds-exercise-solutions/r-markdown.html.