### PR TITLE
correct inline R code for proportion of the large

### DIFF
--- a/rmarkdown/diamond-sizes.Rmd
+++ b/rmarkdown/diamond-sizes.Rmd
@@ -61,7 +61,7 @@ of [Berkson's paradox](https://en.wikipedia.org/wiki/Berkson%27s_paradox).
 ## Largest Diamonds
 
 We have data about `r comma(nrow(diamonds))` diamonds. Only
-`r n_larger` (`r round(nrow(smaller) / nrow(smaller) * 100, 1)`%) are larger
+`r n_larger` (`r round(pct_larger, 1)`%) are larger
 than 2.5 carats. The distribution of the remainder is shown below:
 
 ```{r}


### PR DESCRIPTION
`nrow(smaller) / nrow(smaller)` equals 1, you have 

> We have data about 53,940 diamonds. Only 126 (100%) are larger than 2.5 carats. 

`* 100` is not needed (and actually wrong) since `pct_larger <- n_larger / nrow(diamonds) * 100` already includes it