### PR TITLE
"a, and b" should be "a and b" in Exercise 14.2.6

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -123,19 +123,19 @@ Write a function that turns (e.g.) a vector c("a", "b", "c") into the string a, 
 See the Chapter [Functions] for more details on writing R functions.
 
 ```{r}
-str_commasep <- function(x, sep = ", ", last = ", and ") {
-  if (length(x) > 1) {
-    str_c(str_c(x[-length(x)], collapse = sep),
-                x[length(x)],
-                sep = last)
-  } else {
-    x
-  }
+str_commasep <- function(x, sep = ", ", last = " and ") {
+    if (length(x) <= 1)
+        return(x)
+    if (length(x) == 2)
+        return(str_c(x, collapse = last))
+    
+    x[-length(x)] %>% str_c(collapse = sep) %>% str_c(last, x[length(x)])
 }
 str_commasep("")
 str_commasep("a")
 str_commasep(c("a", "b"))
 str_commasep(c("a", "b", "c"))
+str_commasep(c("a", "b", "c", "d"))
 ```
 
 </div>


### PR DESCRIPTION
```r
str_commasep <- function(x, sep = ", ", last = " and ") {
    if (length(x) <= 1)
        return(x)
    if (length(x) == 2)
        return(str_c(x, collapse = last))
    
    x[-length(x)] %>% str_c(collapse = sep) %>% str_c(last, x[length(x)])
}
str_commasep("")
str_commasep("a")
str_commasep(c("a", "b"))
str_commasep(c("a", "b", "c"))
str_commasep(c("a", "b", "c", "d"))
```

```r
> str_commasep("")
[1] ""

> str_commasep("a")
[1] "a"

> str_commasep(c("a", "b"))
[1] "a and b"

> str_commasep(c("a", "b", "c"))
[1] "a, b and c"

> str_commasep(c("a", "b", "c", "d"))
[1] "a, b, c and d"
```