### PR TITLE
Exercise 15.3.1.2 use `desc(n)`

### DIFF
--- a/factors.Rmd
+++ b/factors.Rmd
@@ -70,7 +70,7 @@ The most common `relig` is "Protestant"
 ```{r}
 gss_cat %>%
   count(relig) %>%
-  arrange(-n) %>%
+  arrange(desc(n)) %>%
   head(1)
 ```
 
@@ -78,7 +78,7 @@ The most common `partyid` is "Independent"
 ```{r}
 gss_cat %>%
   count(partyid) %>%
-  arrange(-n) %>%
+  arrange(desc(n)) %>%
   head(1)
 ```
 


### PR DESCRIPTION
Use `arrange(desc(n))` instead of `arrange(-n)` to make code more readable