### PR TITLE
Exercise 28.2.2: remove redundant aes in geom_point()

### DIFF
--- a/graphics-for-communication.Rmd
+++ b/graphics-for-communication.Rmd
@@ -47,7 +47,7 @@ a better model.
 
 ```{r}
 ggplot(mpg, aes(displ, hwy, colour = class)) +
-  geom_point(aes(colour = class)) +
+  geom_point() +
   geom_smooth(method = "lm", se = FALSE) +
   labs(
     title = "Fuel efficiency generally decreases with engine size",


### PR DESCRIPTION
`aes(colour = class)` already appears in `ggplot()`