### PR TITLE
update code for 16.3.1 to resemble the original book

### DIFF
--- a/datetimes.Rmd
+++ b/datetimes.Rmd
@@ -101,23 +101,23 @@ within a day change over the course of the year?
 
 Let's try plotting this by month:
 ```{r}
-flights_dt %>%
-  mutate(time = hour(dep_time) * 100 + minute(dep_time),
-         mon = as.factor(month
-                         (dep_time))) %>%
-  ggplot(aes(x = time, group = mon, colour = mon)) +
-  geom_freqpoly(binwidth = 100)
+flights_dt %>% 
+  filter(!is.na(dep_time)) %>% 
+    mutate(dep_hour = update(dep_time, yday = 1)) %>% 
+    mutate(month = factor(month(dep_time))) %>%
+  ggplot(aes(dep_hour, color = month)) +
+    geom_freqpoly(binwidth = 60*60)
 ```
 
 This will look better if everything is normalized within groups. The reason
 that February is lower is that there are fewer days and thus fewer flights.
 ```{r}
-flights_dt %>%
-  mutate(time = hour(dep_time) * 100 + minute(dep_time),
-         mon = as.factor(month
-                         (dep_time))) %>%
-  ggplot(aes(x = time, y = ..density.., group = mon, colour = mon)) +
-  geom_freqpoly(binwidth = 100)
+flights_dt %>% 
+  filter(!is.na(dep_time)) %>% 
+    mutate(dep_hour = update(dep_time, yday = 1)) %>% 
+    mutate(month = factor(month(dep_time))) %>%
+  ggplot(aes(dep_hour, color = month)) +
+    geom_freqpoly(aes(y = ..density..), binwidth = 60*60)
 ```
 
 At least to me there doesn't appear to much difference in within-day distribution over the year, but I maybe thinking about it incorrectly.


### PR DESCRIPTION
1. we don't need `hour(dep_time) * 100 + minute(dep_time)`, rather, the book introduces `lubridate::update()`
   > Setting larger components of a date to a constant is a powerful technique that allows you to explore patterns in the smaller components.
1. the former answer is bad-formatted
    ```r
   mon = as.factor(month
                             (dep_time))) %>%
   ```
   these two lines should merge into one
1. `color` is enough for separating lines, we don't need `group` in `aes()`
1. we shouldn't set `y = ..density..` in `ggplot2(aes())`, it's specific for `geom_freqpoly()`

Anyway, the plots looks pretty much the same:

![image](https://user-images.githubusercontent.com/15871952/48660847-98dd2a00-eaa3-11e8-8455-f5253da73312.png)

![image](https://user-images.githubusercontent.com/15871952/48660896-94654100-eaa4-11e8-84c8-9121ed05d64e.png)
