### PR TITLE
fix typo in 5.5.2

### DIFF
--- a/transform.Rmd
+++ b/transform.Rmd
@@ -655,7 +655,7 @@ Compare `dep_time`, `sched_dep_time`, and `dep_delay`. How would you expect thos
 
 <div class="answer">
 
-I would expect the departure delay (`dep_time`) to be equal to the difference between  scheduled departure time (`sched_dep_time`), and actual departure time (`dep_time`),
+I would expect the departure delay (`dep_delay`) to be equal to the difference between  scheduled departure time (`sched_dep_time`), and actual departure time (`dep_time`),
 `dep_time - sched_dep_time = dep_delay`.
 
 As with the previous question, the first step is to convert all times to the 


### PR DESCRIPTION
Changed `dep_time` to `dep_delay` to match correct answer