### PR TITLE
typo in Exercise 14.2.1

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -13,7 +13,7 @@ library(stringr)
 
 <div class="question">
 
-In code that doesn’t stringr, you’ll often see `paste()` and `paste0()`. 
+In code that doesn’t use stringr, you’ll often see `paste()` and `paste0()`. 
 What’s the difference between the two functions? What stringr function are they equivalent to? 
 How do the functions differ in their handling of `NA`?
 


### PR DESCRIPTION
Added "use" to "In code that doesn’t use stringr"