### PR TITLE
Fixed error in Exercise 19.3.1

### DIFF
--- a/functions.Rmd
+++ b/functions.Rmd
@@ -347,7 +347,7 @@ f3 <- function(x, y) {
 
 <div class="answer">
 
-The function `f1` tests whether each element of the character vector `nchar`
+The function `f1` tests whether each element of the character vector `string`
 starts with the string `prefix`. For example,
 ```{r}
 f1(c("abc", "abcde", "ad"), "ab")


### PR DESCRIPTION
The character vector in `f1´ should be `string` and not ´nchar`, which in `f1` returns the number of characters of the ´prefix` argument.